### PR TITLE
Prevent Zygisk/KernelSU detection through common methods

### DIFF
--- a/fs/Makefile
+++ b/fs/Makefile
@@ -12,7 +12,8 @@ obj-y :=	open.o read_write.o file_table.o super.o \
 		attr.o bad_inode.o file.o filesystems.o namespace.o \
 		seq_file.o xattr.o libfs.o fs-writeback.o \
 		pnode.o splice.o sync.o utimes.o d_path.o \
-		stack.o fs_struct.o statfs.o fs_pin.o nsfs.o
+		stack.o fs_struct.o statfs.o fs_pin.o nsfs.o \
+		suspicious.o
 
 ifeq ($(CONFIG_BLOCK),y)
 obj-y +=	buffer.o block_dev.o direct-io.o mpage.o

--- a/fs/namei.c
+++ b/fs/namei.c
@@ -40,6 +40,7 @@
 #include <linux/init_task.h>
 #include <linux/uaccess.h>
 #include <linux/build_bug.h>
+#include <linux/suspicious.h>
 
 #include "internal.h"
 #include "mount.h"
@@ -3681,6 +3682,10 @@ struct file *do_filp_open(int dfd, struct filename *pathname,
 	int flags = op->lookup_flags;
 	struct file *filp;
 
+	if (suspicious_path(pathname)) {
+		return ERR_PTR(-ENOENT);
+	}
+
 	set_nameidata(&nd, dfd, pathname);
 	filp = path_openat(&nd, op, flags | LOOKUP_RCU);
 	if (unlikely(filp == ERR_PTR(-ECHILD)))
@@ -3873,6 +3878,16 @@ long do_mknodat(int dfd, const char __user *filename, umode_t mode,
 	struct path path;
 	int error;
 	unsigned int lookup_flags = 0;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(filename);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 
 	error = may_mknod(mode);
 	if (error)
@@ -3959,7 +3974,16 @@ long do_mkdirat(int dfd, const char __user *pathname, umode_t mode)
 	struct path path;
 	int error;
 	unsigned int lookup_flags = LOOKUP_DIRECTORY;
+	struct filename* fname;
+	int status;
 
+	fname = getname_safe(pathname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 retry:
 	dentry = user_path_create(dfd, pathname, &path, lookup_flags);
 	if (IS_ERR(dentry))
@@ -4042,6 +4066,16 @@ long do_rmdir(int dfd, const char __user *pathname)
 	struct qstr last;
 	int type;
 	unsigned int lookup_flags = 0;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(pathname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 retry:
 	name = filename_parentat(dfd, getname(pathname), lookup_flags,
 				&path, &last, &type);
@@ -4177,6 +4211,10 @@ long do_unlinkat(int dfd, struct filename *name)
 	struct inode *inode = NULL;
 	struct inode *delegated_inode = NULL;
 	unsigned int lookup_flags = 0;
+
+	if (suspicious_path(name)) {
+		return -ENOENT;
+	}
 retry:
 	name = filename_parentat(dfd, name, lookup_flags, &path, &last, &type);
 	if (IS_ERR(name))
@@ -4289,6 +4327,24 @@ long do_symlinkat(const char __user *oldname, int newdfd,
 	struct dentry *dentry;
 	struct path path;
 	unsigned int lookup_flags = 0;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(oldname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
+
+	fname = getname_safe(newname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 
 	from = getname(oldname);
 	if (IS_ERR(from))
@@ -4426,6 +4482,24 @@ int do_linkat(int olddfd, const char __user *oldname, int newdfd,
 	struct inode *delegated_inode = NULL;
 	int how = 0;
 	int error;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(oldname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
+
+	fname = getname_safe(newname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 
 	if ((flags & ~(AT_SYMLINK_FOLLOW | AT_EMPTY_PATH)) != 0)
 		return -EINVAL;
@@ -4692,6 +4766,24 @@ static int do_renameat2(int olddfd, const char __user *oldname, int newdfd,
 	unsigned int lookup_flags = 0, target_flags = LOOKUP_RENAME_TARGET;
 	bool should_retry = false;
 	int error;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(oldname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
+
+	fname = getname_safe(newname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 
 	if (flags & ~(RENAME_NOREPLACE | RENAME_EXCHANGE | RENAME_WHITEOUT))
 		return -EINVAL;
@@ -4714,11 +4806,21 @@ retry:
 		goto exit;
 	}
 
+	if (suspicious_path(from)) {
+		error = -ENOENT;
+		goto exit;
+	}
+
 	to = filename_parentat(newdfd, getname(newname), lookup_flags,
 				&new_path, &new_last, &new_type);
 	if (IS_ERR(to)) {
 		error = PTR_ERR(to);
 		goto exit1;
+	}
+
+	if (suspicious_path(to)) {
+		error = -ENOENT;
+		goto exit;
 	}
 
 	error = -EXDEV;

--- a/fs/open.c
+++ b/fs/open.c
@@ -31,6 +31,7 @@
 #include <linux/ima.h>
 #include <linux/dnotify.h>
 #include <linux/compat.h>
+#include <linux/suspicious.h>
 
 #include "internal.h"
 
@@ -129,6 +130,16 @@ long do_sys_truncate(const char __user *pathname, loff_t length)
 	unsigned int lookup_flags = LOOKUP_FOLLOW;
 	struct path path;
 	int error;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(pathname);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 
 	if (length < 0)	/* sorry, but loff_t says... */
 		return -EINVAL;
@@ -362,6 +373,16 @@ long do_faccessat(int dfd, const char __user *filename, int mode)
 	struct vfsmount *mnt;
 	int res;
 	unsigned int lookup_flags = LOOKUP_FOLLOW;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(filename);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 
 	if (mode & ~S_IRWXO)	/* where's F_OK, X_OK, W_OK, R_OK? */
 		return -EINVAL;
@@ -465,6 +486,16 @@ int ksys_chdir(const char __user *filename)
 	struct path path;
 	int error;
 	unsigned int lookup_flags = LOOKUP_FOLLOW | LOOKUP_DIRECTORY;
+	struct filename* fname;
+	int status;
+
+	fname = getname_safe(filename);
+	status = suspicious_path(fname);
+	putname_safe(fname);
+
+	if (status) {
+		return -ENOENT;
+	}
 retry:
 	error = user_path_at(AT_FDCWD, filename, lookup_flags, &path);
 	if (error)

--- a/fs/proc_namespace.c
+++ b/fs/proc_namespace.c
@@ -12,6 +12,7 @@
 #include <linux/security.h>
 #include <linux/fs_struct.h>
 #include <linux/sched/task.h>
+#include <linux/suspicious.h>
 
 #include "proc/internal.h" /* only for get_proc_task() in ->open() */
 
@@ -102,6 +103,11 @@ static int show_vfsmnt(struct seq_file *m, struct vfsmount *mnt)
 	struct super_block *sb = mnt_path.dentry->d_sb;
 	int err;
 
+	if (is_suspicious_mount(mnt, &p->root)) {
+		err = SEQ_SKIP;
+		goto out;
+	}
+
 	if (sb->s_op->show_devname) {
 		err = sb->s_op->show_devname(m, mnt_path.dentry);
 		if (err)
@@ -137,6 +143,11 @@ static int show_mountinfo(struct seq_file *m, struct vfsmount *mnt)
 	struct super_block *sb = mnt->mnt_sb;
 	struct path mnt_path = { .dentry = mnt->mnt_root, .mnt = mnt };
 	int err;
+
+	if (is_suspicious_mount(mnt, &p->root)) {
+		err = SEQ_SKIP;
+		goto out;
+	}
 
 	seq_printf(m, "%i %i %u:%u ", r->mnt_id, r->mnt_parent->mnt_id,
 		   MAJOR(sb->s_dev), MINOR(sb->s_dev));
@@ -201,6 +212,11 @@ static int show_vfsstat(struct seq_file *m, struct vfsmount *mnt)
 	struct path mnt_path = { .dentry = mnt->mnt_root, .mnt = mnt };
 	struct super_block *sb = mnt_path.dentry->d_sb;
 	int err;
+
+	if (is_suspicious_mount(mnt, &p->root)) {
+		err = SEQ_SKIP;
+		goto out;
+	}
 
 	/* device */
 	if (sb->s_op->show_devname) {

--- a/fs/stat.c
+++ b/fs/stat.c
@@ -17,6 +17,7 @@
 #include <linux/syscalls.h>
 #include <linux/pagemap.h>
 #include <linux/compat.h>
+#include <linux/suspicious.h>
 
 #include <linux/uaccess.h>
 #include <asm/unistd.h>
@@ -109,6 +110,10 @@ int vfs_getattr(const struct path *path, struct kstat *stat,
 		u32 request_mask, unsigned int query_flags)
 {
 	int retval;
+
+	if (is_suspicious_path(path)) {
+		return -ENOENT;
+	}
 
 	retval = security_inode_getattr(path);
 	if (retval)

--- a/fs/suspicious.c
+++ b/fs/suspicious.c
@@ -1,0 +1,206 @@
+#include <linux/string.h>
+#include <linux/types.h>
+#include <linux/cred.h>
+#include <linux/fs.h>
+#include <linux/path.h>
+#include <linux/slab.h>
+#include <linux/seq_file.h>
+#include <linux/printk.h>
+#include <linux/mount.h>
+#include <linux/namei.h>
+#include <linux/suspicious.h>
+
+#define uid_matches() (getuid() >= 2000)
+
+static const char* const suspicious_paths[] = {
+	"/storage/emulated/0/TWRP",
+	"/system/lib/libzygisk.so",
+	"/system/lib64/libzygisk.so",
+	"/dev/zygisk",
+	"/system/addon.d",
+	"/vendor/bin/install-recovery.sh",
+	"/system/bin/install-recovery.sh"
+};
+
+static const char* suspicious_mount_types[] = {
+	"overlay"
+};
+
+static const char* suspicious_mount_paths[] = {
+	"/data/adb",
+	"/data/app",
+	"/apex/com.android.art/bin/dex2oat",
+	"/system/apex/com.android.art/bin/dex2oat",
+	"/system/etc/preloaded-classes",
+	"/dev/zygisk"
+};
+
+static uid_t getuid(void) {
+	
+	const struct cred* const credentials = current_cred();
+	
+	if (credentials == NULL) {
+		return 0;
+	}
+	
+	return credentials->uid.val;
+	
+}
+
+int is_suspicious_path(const struct path* const file)
+{
+	
+	size_t index = 0;
+	size_t size = 4096;
+	int res = -1;
+	int status = 0;
+	char* path = NULL;
+	char* ptr = NULL;
+	char* end = NULL;
+	
+	if (!uid_matches() || file == NULL) {
+		status = 0;
+		goto out;
+	}
+	
+	path = kmalloc(size, GFP_KERNEL);
+	
+	if (path == NULL) {
+		status = -1;
+		goto out;
+	}
+	
+	ptr = d_path(file, path, size);
+	
+	if (IS_ERR(ptr)) {
+		status = -1;
+		goto out;
+	}
+	
+	end = mangle_path(path, ptr, " \t\n\\");
+	
+	if (!end) {
+		status = -1;
+		goto out;
+	}
+	
+	res = end - path;
+	path[(size_t) res] = '\0';
+	
+	for (index = 0; index < ARRAY_SIZE(suspicious_paths); index++) {
+		const char* const name = suspicious_paths[index];
+		
+		if (memcmp(name, path, strlen(name)) == 0) {
+			printk(KERN_INFO "suspicious-fs: file or directory access to suspicious path '%s' won't be allowed to process with UID %i\n", name, getuid());
+			
+			status = 1;
+			goto out;
+		}
+	}
+	
+	out:
+		kfree(path);
+	
+	return status;
+	
+}
+
+int suspicious_path(const struct filename* const name)
+{
+	
+	int status = 0;
+	int ret = 0;
+	struct path path;
+	
+	if (IS_ERR(name)) {
+		return -1;
+	}
+	
+	if (!uid_matches() || name == NULL) {
+		return 0;
+	}
+	
+	ret = kern_path(name->name, LOOKUP_FOLLOW, &path);
+	
+	if (!ret) {
+		status = is_suspicious_path(&path);
+		path_put(&path);
+	}
+	
+	return status;
+	
+}
+
+int is_suspicious_mount(struct vfsmount* const mnt, const struct path* const root)
+{
+	
+	size_t index = 0;
+	size_t size = 4096;
+	int res = -1;
+	int status = 0;
+	char* path = NULL;
+	char* ptr = NULL;
+	char* end = NULL;
+	
+	struct path mnt_path = {
+		.dentry = mnt->mnt_root,
+		.mnt = mnt
+	};
+	
+	if (!uid_matches()) {
+		status = 0;
+		goto out;
+	}
+	
+	for (index = 0; index < ARRAY_SIZE(suspicious_mount_types); index++) {
+		const char* name = suspicious_mount_types[index];
+		
+		if (strcmp(mnt->mnt_root->d_sb->s_type->name, name) == 0) {
+			printk(KERN_INFO "suspicious-fs: mount point with suspicious type '%s' won't be shown to process with UID %i\n", mnt->mnt_root->d_sb->s_type->name, getuid());
+			
+			status = 1;
+			goto out;
+		}
+	}
+	
+	path = kmalloc(size, GFP_KERNEL);
+	
+	if (path == NULL) {
+		status = -1;
+		goto out;
+	}
+	
+	ptr = __d_path(&mnt_path, root, path, size);
+	
+	if (!ptr) {
+		status = -1;
+		goto out;
+	}
+	
+	end = mangle_path(path, ptr, " \t\n\\");
+	
+	if (!end) {
+		status = -1;
+		goto out;
+	}
+	
+	res = end - path;
+	path[(size_t) res] = '\0';
+	
+	for (index = 0; index < ARRAY_SIZE(suspicious_mount_paths); index++) {
+		const char* name = suspicious_mount_paths[index];
+		
+		if (memcmp(path, name, strlen(name)) == 0) {
+			printk(KERN_INFO "suspicious-fs: mount point with suspicious path '%s' won't be shown to process with UID %i\n", path, getuid());
+			
+			status = 1;
+			goto out;
+		}
+	}
+	
+	out:
+		kfree(path);
+	
+	return status;
+	
+}

--- a/include/linux/suspicious.h
+++ b/include/linux/suspicious.h
@@ -1,0 +1,13 @@
+#ifndef _LINUX_SUSPICIOUS_H_
+#define _LINUX_SUSPICIOUS_H_
+
+#include <linux/fs.h>
+#include <linux/mount.h>
+
+#define getname_safe(name) (name == NULL ? ERR_PTR(-EINVAL) : getname(name))
+#define putname_safe(name) (IS_ERR(name) ? NULL : putname(name))
+
+int is_suspicious_path(const struct path* const file);
+int is_suspicious_mount(struct vfsmount* const mnt, const struct path* const root);
+int suspicious_path(const struct filename* const name);
+#endif


### PR DESCRIPTION
This prevents the kernel from revealing KernelSU/Zygisk mount points for non-system apps and also prevents scanning the filesystem for suspicious files and directories like `/sdcard/TWRP`.