### PR TITLE
dts: add panel-nt36672a-truly-v2-video

### DIFF
--- a/arch/arm64/boot/dts/vendor/qcom/bengal-idp.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/bengal-idp.dtsi
@@ -464,6 +464,18 @@
 	qcom,platform-bklight-en-gpio = <&tlmm 99 0>;
 };
 
+&dsi_nt36672a_truly_v2_video {
+	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
+	qcom,mdss-dsi-bl-pmic-control-type = "bl_ctrl_pwm";
+	pwms = <&pm6125_pwm 0 0>;
+	qcom,bl-pmic-pwm-period-usecs = <100>;
+	qcom,mdss-dsi-bl-min-level = <1>;
+	qcom,mdss-dsi-bl-max-level = <4095>;
+	qcom,mdss-brightness-max-level = <4095>;
+	qcom,platform-reset-gpio = <&tlmm 85 0>;
+	qcom,platform-bklight-en-gpio = <&tlmm 99 0>;
+};
+
 /*
 &dsi_td4330_truly_v2_cmd {
 	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;
@@ -501,8 +513,9 @@
 	qcom,platform-bklight-en-gpio = <&pmi632_gpios 6 0>;
 };
 */
+
 &sde_dsi {
-	qcom,dsi-default-panel = <&dsi_td4330_truly_v2_video &dsi_ft8719_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672d_xinli_v2_video>;
+	qcom,dsi-default-panel = <&dsi_td4330_truly_v2_video &dsi_ft8719_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672a_truly_v2_video &dsi_nt36672d_xinli_v2_video>;
 };
 
 /*
@@ -668,7 +681,7 @@
 	/* Novatek device tree node */
 	novatek@1 {
 		compatible = "novatek,NVT-ts-spi";
-		panel = <&dsi_td4330_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672d_xinli_v2_video>;
+		panel = <&dsi_td4330_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672a_truly_v2_video &dsi_nt36672d_xinli_v2_video>;
 		reg = <1>; //Same as CS ID
 		status = "ok";
 

--- a/arch/arm64/boot/dts/vendor/qcom/bengal-sde-display.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/bengal-sde-display.dtsi
@@ -1,6 +1,7 @@
 #include "dsi-panel-td4330-truly-v2-singlemipi-fhd-cmd.dtsi"
 #include "dsi-panel-td4330-truly-v2-singlemipi-fhd-vid.dtsi"
 #include "dsi-panel-nt36525-truly-hd-plus-vid.dtsi"
+#include "dsi-panel-nt36672a-truly-v2-video.dtsi"
 
 #include "dsi-panel-nt36672a-tianma-fhd-video.dtsi"
 #include "dsi-panel-ft8719-truly-fhd-vid.dtsi"
@@ -126,7 +127,7 @@
 		qcom,mdp = <&mdss_mdp>;
 
 		qcom,dsi-default-panel =
-			<&dsi_td4330_truly_v2_video &dsi_ft8719_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672d_xinli_v2_video>;
+			<&dsi_td4330_truly_v2_video &dsi_ft8719_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672a_truly_v2_video &dsi_nt36672d_xinli_v2_video>;
 	};
 
 	sde_wb: qcom,wb-display@0 {
@@ -138,7 +139,7 @@
 
 	msm_notifier: qcom,msm_notifier@0 {
 		compatible = "qcom,msm-notifier";
-		panel = <&dsi_td4330_truly_v2_video &dsi_ft8719_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672d_xinli_v2_video>;
+		panel = <&dsi_td4330_truly_v2_video &dsi_ft8719_truly_v2_video &dsi_nt36672d_tianma_v2_video &dsi_nt36672a_truly_v2_video &dsi_nt36672d_xinli_v2_video>;
 
 	};
 };
@@ -219,6 +220,37 @@
 		};
 	};
 };
+
+&dsi_nt36672a_truly_v2_video {
+	qcom,esd-check-enabled;
+	qcom,mdss-dsi-panel-status-check-mode = "reg_read";
+	qcom,mdss-dsi-panel-status-command = <0x6010001 0x10a>;
+	qcom,mdss-dsi-panel-status-command-state = "dsi_lp_mode";
+	qcom,mdss-dsi-panel-status-value = <0x9c>;
+	qcom,mdss-dsi-panel-status-read-length = <0x01>;
+	qcom,mdss-dsi-panel-max-error-count = <0x03>;
+	qcom,mdss-dsi-t-clk-post = <0x0f>;
+	qcom,mdss-dsi-t-clk-pre = <0x37>;
+	qcom,mdss-dsi-panel-framerate = <60>;
+        qcom,dsi-select-clocks = "mux_byte_clk0", "mux_pixel_clk0",
+				"src_byte_clk0", "src_pixel_clk0",
+				"shadow_byte_clk0", "shadow_pixel_clk0";
+	qcom,dsi-dyn-clk-list = <0x3a2f7bc0 0x3ae9ad50 0x3aab9cc8 0x3a6d8c48>;
+	qcom,dsi-dyn-clk-type = "constant-fps-adjust-vfp";
+	qcom,mdss-dsi-display-timings {
+		timing@0{
+			qcom,mdss-dsi-panel-phy-timings = 
+				[26 20 09 0A 06 02 04 A0
+				26 20 09 0A 06 02 04 A0 
+				26 20 09 0A 06 02 04 A0 
+				26 20 09 0A 06 02 04 A0 
+				26 1F 09 0A 06 02 04 A0];
+			qcom,display-topology = <1 0 1>;
+			qcom,default-topology-index = <0>;
+		};
+	};
+};
+
 //chenwenmin
 &dsi_nt36672a_tianma_video {
 	qcom,panel-supply-entries = <&dsi_panel_pwr_supply>;

--- a/arch/arm64/boot/dts/vendor/qcom/dsi-panel-nt36672a-truly-v2-video.dtsi
+++ b/arch/arm64/boot/dts/vendor/qcom/dsi-panel-nt36672a-truly-v2-video.dtsi
@@ -1,0 +1,73 @@
+&mdss_mdp {
+	dsi_nt36672a_truly_v2_video: qcom,mdss_dsi_nt36672a_truly_v2_video {
+		qcom,mdss-dsi-panel-name = "nt36672a truly video mode dsi truly panel";
+		qcom,mdss-dsi-panel-type = "dsi_video_mode";
+		qcom,dsi-ctrl-num = <0x00>;
+		qcom,dsi-phy-num = <0x00>;
+		qcom,mdss-dsi-virtual-channel-id = <0x00>;
+		qcom,mdss-dsi-stream = <0x00>;
+		qcom,mdss-dsi-h-left-border = <0x00>;
+		qcom,mdss-dsi-h-right-border = <0x00>;
+		qcom,mdss-dsi-v-top-border = <0x00>;
+		qcom,mdss-dsi-v-bottom-border = <0x00>;
+		qcom,mdss-dsi-bpp = <0x18>;
+		qcom,mdss-dsi-color-order = "rgb_swap_rgb";
+		qcom,mdss-dsi-underflow-color = <0xff>;
+		qcom,mdss-dsi-border-color = <0x00>;
+		qcom,mdss-dsi-h-sync-pulse = <0x00>;
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_event";
+		qcom,mdss-dsi-lane-map = "lane_map_0123";
+		qcom,mdss-dsi-bllp-eof-power-mode;
+		qcom,mdss-dsi-bllp-power-mode;
+		qcom,mdss-dsi-tx-eot-append;
+		qcom,mdss-dsi-lane-0-state;
+		qcom,mdss-dsi-lane-1-state;
+		qcom,mdss-dsi-lane-2-state;
+		qcom,mdss-dsi-lane-3-state;
+		qcom,mdss-dsi-dma-trigger = "trigger_sw";
+		qcom,mdss-dsi-mdp-trigger = "none";
+		qcom,mdss-dsi-lp11-init;
+		qcom,mdss-dsi-reset-sequence = <0x01 0x0a 0x00 0x0a 0x01 0x14>;
+		qcom,mdss-pan-physical-width-dimension = <0x45>;
+		qcom,mdss-pan-physical-height-dimension = <0x96>;
+		qcom,mdss-dsi-te-pin-select = <0x01>;
+		qcom,mdss-dsi-wr-mem-start = <0x2c>;
+		qcom,mdss-dsi-wr-mem-continue = <0x3c>;
+		qcom,mdss-dsi-te-dcs-command = <0x01>;
+		qcom,mdss-dsi-te-check-enable;
+		qcom,mdss-dsi-te-using-te-pin;
+		qcom,dsi-supported-dfps-list = <0x3c 0x37 0x30>;
+		qcom,mdss-dsi-pan-fps-update = "dfps_immediate_porch_mode_vfp";
+		qcom,mdss-dsi-bl-max-level = <0xfff>;
+		//phandle = <0x12>;
+
+		qcom,mdss-dsi-display-timings {
+
+			timing@0 {
+			qcom,mdss-dsi-panel-width = <0x438>;
+			qcom,mdss-dsi-panel-height = <0x924>;
+			qcom,mdss-dsi-h-front-porch = <0x4c>;
+			qcom,mdss-dsi-h-back-porch = <0x38>;
+			qcom,mdss-dsi-h-pulse-width = <0x0c>;
+			qcom,mdss-dsi-h-sync-skew = <0x00>;
+			qcom,mdss-dsi-v-back-porch = <0x0f>;
+			qcom,mdss-dsi-v-front-porch = <0x20>;
+			qcom,mdss-dsi-v-pulse-width = <0x02>;
+			qcom,mdss-dsi-panel-framerate = <0x3c>;
+			qcom,mdss-dsi-on-command = [39 01 00 00 00 00 02 ff 23 39 01 00 00 00 00 02 fb 01 39 01 00 00 00 00 02 00 80 39 01 00 00 00 00 02 07 00 39 01 00 00 00 00 02 08 01 39 01 00 00 00 00 02 09 00 39 01 00 00 00 00 02 ff f0 39 01 00 00 00 00 02 fb 01 39 01 00 00 00 00 02 a2 00 39 01 00 00 00 00 02 ff 10 05 01 00 00 78 00 02 11 00 39 01 00 00 00 00 02 35 00 39 01 00 00 00 00 03 51 0f ff 39 01 00 00 00 00 02 53 2c 39 01 00 00 00 00 02 55 01 39 01 00 00 00 00 02 ff 23 39 01 00 00 00 00 02 fb 01 39 01 00 00 00 00 02 10 50 39 01 00 00 00 00 02 11 01 39 01 00 00 00 00 02 12 8a 39 01 00 00 00 00 02 15 6a 39 01 00 00 00 00 02 16 0b 39 01 00 00 00 00 02 29 80 39 01 00 00 00 00 02 30 fd 39 01 00 00 00 00 02 31 fc 39 01 00 00 00 00 02 32 f8 39 01 00 00 00 00 02 33 f6 39 01 00 00 00 00 02 34 f5 39 01 00 00 00 00 02 35 f4 39 01 00 00 00 00 02 36 f3 39 01 00 00 00 00 02 37 f3 39 01 00 00 00 00 02 38 f2 39 01 00 00 00 00 02 39 f0 39 01 00 00 00 00 02 3a ee 39 01 00 00 00 00 02 3b ec 39 01 00 00 00 00 02 3d ea 39 01 00 00 00 00 02 3f e8 39 01 00 00 00 00 02 40 e6 39 01 00 00 00 00 02 41 e5 39 01 00 00 00 00 02 45 e4 39 01 00 00 00 00 02 46 e4 39 01 00 00 00 00 02 47 e4 39 01 00 00 00 00 02 48 e4 39 01 00 00 00 00 02 49 e4 39 01 00 00 00 00 02 4a e4 39 01 00 00 00 00 02 4b d0 39 01 00 00 00 00 02 4c b2 39 01 00 00 00 00 02 4d af 39 01 00 00 00 00 02 4e aa 39 01 00 00 00 00 02 4f a4 39 01 00 00 00 00 02 50 9a 39 01 00 00 00 00 02 51 90 39 01 00 00 00 00 02 52 85 39 01 00 00 00 00 02 53 7a 39 01 00 00 00 00 02 54 66 39 01 00 00 00 00 02 2b 87 39 01 00 00 00 00 02 58 e4 39 01 00 00 00 00 02 59 e4 39 01 00 00 00 00 02 5a e4 39 01 00 00 00 00 02 5b e4 39 01 00 00 00 00 02 5c e4 39 01 00 00 00 00 02 5d e4 39 01 00 00 00 00 02 5e df 39 01 00 00 00 00 02 5f da 39 01 00 00 00 00 02 60 d7 39 01 00 00 00 00 02 61 d0 39 01 00 00 00 00 02 62 cd 39 01 00 00 00 00 02 63 ca 39 01 00 00 00 00 02 64 c8 39 01 00 00 00 00 02 65 c1 39 01 00 00 00 00 02 66 bb 39 01 00 00 00 00 02 67 b3 39 01 00 00 00 00 02 ff 10 05 01 00 00 14 00 02 29 00];
+			qcom,mdss-dsi-off-command = [05 01 00 00 14 00 02 28 00 05 01 00 00 8c 00 02 10 00 39 01 00 00 00 00 02 00 00 39 01 00 00 00 00 05 f7 5a a5 95 27];
+			qcom,mdss-dsi-cabc-on-command = [39 01 00 00 00 00 02 55 01];
+			qcom,mdss-dsi-cabc-off-command = [39 01 00 00 00 00 02 55 00];
+			qcom,mdss-dsi-cabc_movie-on-command = [39 01 00 00 00 00 02 55 03];
+			qcom,mdss-dsi-cabc_still-on-command = [39 01 00 00 00 00 02 55 02];
+			qcom,mdss-dsi-on-command-state = "dsi_lp_mode";
+			qcom,mdss-dsi-off-command-state = "dsi_hs_mode";
+			qcom,mdss-dsi-cabc-on-command-state = "dsi_hs_mode";
+			qcom,mdss-dsi-cabc-off-command-state = "dsi_hs_mode";
+			qcom,mdss-dsi-cabc_movie-on-command-state = "dsi_hs_mode";
+			qcom,mdss-dsi-cabc_still-on-command-state = "dsi_hs_mode";
+			};
+		};
+	};
+};
+


### PR DESCRIPTION
- Extracted from citrus global V12.5.10.0 dtbo.img.
- Fixes black screen on boot issue.
- Tested on my citrus device with affected panel.
